### PR TITLE
fix: replace nuxthub deploy with wrangler pages deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Build application
         run: npm run build
 
-      - name: Deploy to NuxtHub
+      - name: Deploy to Cloudflare Pages
         env:
-          NUXT_HUB_PROJECT_KEY: ${{ secrets.NUXT_HUB_PROJECT_KEY }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        run: npx nuxthub deploy --production
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: npx wrangler pages deploy dist --project-name=recipe-remix --branch=main

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      pull-requests: write  # Allow commenting on PR
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
@@ -29,12 +29,11 @@ jobs:
       - name: Deploy preview
         id: deploy
         env:
-          NUXT_HUB_PROJECT_KEY: ${{ secrets.NUXT_HUB_PROJECT_KEY }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
-          OUTPUT=$(npx nuxthub deploy --preview 2>&1)
+          OUTPUT=$(npx wrangler pages deploy dist --project-name=recipe-remix --branch=preview-${{ github.event.pull_request.number }} 2>&1)
           echo "$OUTPUT"
-          # Extract preview URL from output (format: "Deployed to https://...")
           PREVIEW_URL=$(echo "$OUTPUT" | grep -o 'https://[^ ]*pages.dev' | head -1)
           echo "preview_url=$PREVIEW_URL" >> $GITHUB_OUTPUT
 
@@ -47,5 +46,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `## 🚀 Preview Deployment Ready\n\n**URL:** ${{ steps.deploy.outputs.preview_url }}\n\nTest this preview before merging to production.`
+              body: `## Preview Deployment Ready\n\n**URL:** ${{ steps.deploy.outputs.preview_url }}\n\nTest this preview before merging to production.`
             })


### PR DESCRIPTION
## Summary
Closes #3

NuxtHub CLI is sunset and fails in headless CI with:
```
[error] nuxthub login is not supported in headless mode yet.
```

Replaced `npx nuxthub deploy` with `npx wrangler pages deploy` in both workflows.

## Changes
- `deploy.yml`: Use `wrangler pages deploy dist --project-name=recipe-remix --branch=main`
- `preview.yml`: Use `wrangler pages deploy dist --project-name=recipe-remix --branch=preview-{PR#}`
- Replaced `NUXT_HUB_PROJECT_KEY` with `CLOUDFLARE_ACCOUNT_ID` secret

## Required Secret
Add **`CLOUDFLARE_ACCOUNT_ID`** to GitHub repo secrets (Settings > Secrets > Actions).
You can find it in Cloudflare dashboard URL: `dash.cloudflare.com/{account_id}`

## Test plan
- [ ] Merge and verify deploy workflow succeeds
- [ ] Smoke tests trigger after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)